### PR TITLE
Abstraction/service abstraction

### DIFF
--- a/src/main/java/com/example/study/controller/CrudController.java
+++ b/src/main/java/com/example/study/controller/CrudController.java
@@ -1,12 +1,17 @@
-package com.example.study.controller.api;
+package com.example.study.controller;
 
 import com.example.study.ifs.CrudInterface;
 import com.example.study.model.network.Header;
+import com.example.study.service.BaseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 
-public abstract class CrudController<Req, Res> implements CrudInterface<Req, Res> {
+@Component
+public abstract class CrudController<Req, Res, Entity> implements CrudInterface<Req, Res> {
 
-    protected CrudInterface<Req, Res> baseService;
+    @Autowired(required = false)
+    protected BaseService<Req, Res, Entity> baseService;
 
     @Override
     @PostMapping("")

--- a/src/main/java/com/example/study/controller/api/ItemApiController.java
+++ b/src/main/java/com/example/study/controller/api/ItemApiController.java
@@ -1,25 +1,18 @@
 package com.example.study.controller.api;
 
+import com.example.study.controller.CrudController;
+import com.example.study.model.entity.Item;
 import com.example.study.model.network.request.ItemApiRequest;
 import com.example.study.model.network.response.ItemApiResponse;
-import com.example.study.service.ItemApiLogicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.PostConstruct;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/item")
 @RequiredArgsConstructor
-public class ItemApiController extends CrudController<ItemApiRequest, ItemApiResponse> {
+public class ItemApiController extends CrudController<ItemApiRequest, ItemApiResponse, Item> {
 
-    private final ItemApiLogicService itemApiLogicService;
-
-    @PostConstruct
-    public void init(){
-        this.baseService = itemApiLogicService;
-    }
 }

--- a/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
+++ b/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
@@ -4,13 +4,10 @@ import com.example.study.controller.CrudController;
 import com.example.study.model.entity.OrderGroup;
 import com.example.study.model.network.request.OrderGroupApiRequest;
 import com.example.study.model.network.request.OrderGroupApiResponse;
-import com.example.study.service.OrderGroupApiLogicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.annotation.PostConstruct;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
+++ b/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
@@ -1,24 +1,18 @@
 package com.example.study.controller.api;
 
+import com.example.study.controller.CrudController;
+import com.example.study.model.entity.OrderGroup;
 import com.example.study.model.network.request.OrderGroupApiRequest;
 import com.example.study.model.network.request.OrderGroupApiResponse;
-import com.example.study.service.OrderGroupApiLogicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.PostConstruct;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/order-group")
 @RequiredArgsConstructor
-public class OrderGroupApiController extends CrudController<OrderGroupApiRequest, OrderGroupApiResponse> {
-    private final OrderGroupApiLogicService orderGroupApiLogicService;
+public class OrderGroupApiController extends CrudController<OrderGroupApiRequest, OrderGroupApiResponse, OrderGroup> {
 
-    @PostConstruct
-    protected void init(){
-        baseService = orderGroupApiLogicService;
-    }
 }

--- a/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
+++ b/src/main/java/com/example/study/controller/api/OrderGroupApiController.java
@@ -4,10 +4,13 @@ import com.example.study.controller.CrudController;
 import com.example.study.model.entity.OrderGroup;
 import com.example.study.model.network.request.OrderGroupApiRequest;
 import com.example.study.model.network.request.OrderGroupApiResponse;
+import com.example.study.service.OrderGroupApiLogicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/example/study/controller/api/UserApiController.java
+++ b/src/main/java/com/example/study/controller/api/UserApiController.java
@@ -1,25 +1,18 @@
 package com.example.study.controller.api;
 
+import com.example.study.controller.CrudController;
+import com.example.study.model.entity.User;
 import com.example.study.model.network.request.UserApiRequest;
 import com.example.study.model.network.response.UserApiResponse;
-import com.example.study.service.UserApiLogicService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.PostConstruct;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/user")
 @RequiredArgsConstructor
-public class UserApiController extends CrudController<UserApiRequest, UserApiResponse> {
+public class UserApiController extends CrudController<UserApiRequest, UserApiResponse, User> {
 
-    private final UserApiLogicService userApiLogicService;
-
-    @PostConstruct
-    protected void init(){
-        baseService = userApiLogicService;
-    }
 }

--- a/src/main/java/com/example/study/service/BaseService.java
+++ b/src/main/java/com/example/study/service/BaseService.java
@@ -1,0 +1,13 @@
+package com.example.study.service;
+
+import com.example.study.ifs.CrudInterface;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class BaseService<Req, Res, Entity> implements CrudInterface<Req, Res> {
+
+    @Autowired(required = false)
+    protected JpaRepository<Entity, Long> baseRepository;
+}

--- a/src/main/java/com/example/study/service/ItemApiLogicService.java
+++ b/src/main/java/com/example/study/service/ItemApiLogicService.java
@@ -1,12 +1,10 @@
 package com.example.study.service;
 
-import com.example.study.ifs.CrudInterface;
 import com.example.study.model.entity.Item;
 import com.example.study.model.enumClass.ItemStatus;
 import com.example.study.model.network.Header;
 import com.example.study.model.network.request.ItemApiRequest;
 import com.example.study.model.network.response.ItemApiResponse;
-import com.example.study.repository.ItemRepository;
 import com.example.study.repository.PartnerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,10 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
-public class ItemApiLogicService implements CrudInterface<ItemApiRequest, ItemApiResponse> {
-
-    @Autowired
-    private ItemRepository itemRepository;
+public class ItemApiLogicService extends BaseService<ItemApiRequest, ItemApiResponse, Item> {
 
     @Autowired
     private PartnerRepository partnerRepository;
@@ -37,13 +32,13 @@ public class ItemApiLogicService implements CrudInterface<ItemApiRequest, ItemAp
                 .partner(partnerRepository.getOne(body.getPartnerId()))
                 .build();
 
-        Item newItem=itemRepository.save(item);
+        Item newItem=baseRepository.save(item);
         return getResponse(newItem);
     }
 
     @Override
     public Header<ItemApiResponse> read(Long id) {
-        Optional<Item> opt=itemRepository.findById(id);
+        Optional<Item> opt=baseRepository.findById(id);
         return opt.map(item->getResponse(item))
                 .orElseGet(()->Header.ERROR("데이터 없음."));
     }
@@ -53,7 +48,7 @@ public class ItemApiLogicService implements CrudInterface<ItemApiRequest, ItemAp
         ItemApiRequest body = request.getData();
 
         // 업데이트할 데이터 찾기
-        Optional<Item> opt=itemRepository.findById(body.getId());
+        Optional<Item> opt=baseRepository.findById(body.getId());
 
         // update
         return opt.map(item->{
@@ -67,16 +62,16 @@ public class ItemApiLogicService implements CrudInterface<ItemApiRequest, ItemAp
                 item.setUnregisteredAt(LocalDateTime.now());     // unregisteredAt 필드 업데이트
             return item;
         })
-                .map(item -> itemRepository.save(item))
+                .map(item -> baseRepository.save(item))
                 .map(item -> getResponse(item))
                 .orElseGet(()->Header.ERROR("데이터 없음."));
     }
 
     @Override
     public Header delete(Long id) {
-        Optional<Item> opt = itemRepository.findById(id);
+        Optional<Item> opt = baseRepository.findById(id);
         return opt.map(item->{
-            itemRepository.delete(item);
+            baseRepository.delete(item);
             return Header.OK();
         }).orElseGet(()->Header.ERROR("데이터 없음."));
     }

--- a/src/main/java/com/example/study/service/OrderGroupApiLogicService.java
+++ b/src/main/java/com/example/study/service/OrderGroupApiLogicService.java
@@ -1,11 +1,9 @@
 package com.example.study.service;
 
-import com.example.study.ifs.CrudInterface;
 import com.example.study.model.entity.OrderGroup;
 import com.example.study.model.network.Header;
 import com.example.study.model.network.request.OrderGroupApiRequest;
 import com.example.study.model.network.request.OrderGroupApiResponse;
-import com.example.study.repository.OrderGroupRepository;
 import com.example.study.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +14,7 @@ import java.util.Optional;
 
 @Service
 @Slf4j
-public class OrderGroupApiLogicService implements CrudInterface<OrderGroupApiRequest, OrderGroupApiResponse> {
-
-    @Autowired
-    private OrderGroupRepository orderGroupRepository;
+public class OrderGroupApiLogicService extends BaseService<OrderGroupApiRequest, OrderGroupApiResponse, OrderGroup> {
 
     @Autowired
     private UserRepository userRepository;
@@ -39,13 +34,13 @@ public class OrderGroupApiLogicService implements CrudInterface<OrderGroupApiReq
                 .user(userRepository.getOne(body.getUserId()))
                 .build();
 
-        OrderGroup newOrderGroup = orderGroupRepository.save(orderGroup);
+        OrderGroup newOrderGroup = baseRepository.save(orderGroup);
         return getResponse(newOrderGroup);
     }
 
     @Override
     public Header<OrderGroupApiResponse> read(Long id) {
-        Optional<OrderGroup> opt=orderGroupRepository.findById(id);
+        Optional<OrderGroup> opt=baseRepository.findById(id);
         return opt
                 .map(orderGroup->getResponse(orderGroup))
                 .orElseGet(()->Header.ERROR("데이터 없음."));
@@ -55,7 +50,7 @@ public class OrderGroupApiLogicService implements CrudInterface<OrderGroupApiReq
     public Header<OrderGroupApiResponse> update(Header<OrderGroupApiRequest> request) {
         OrderGroupApiRequest body = request.getData();
         log.info("id : " + body.getId());
-        Optional<OrderGroup> opt = orderGroupRepository.findById(body.getId());
+        Optional<OrderGroup> opt = baseRepository.findById(body.getId());
         return opt
                 .map(orderGroup -> {
                     log.info("Exist.");
@@ -72,17 +67,17 @@ public class OrderGroupApiLogicService implements CrudInterface<OrderGroupApiReq
 
                     return orderGroup;
                 })
-                .map(orderGroup -> orderGroupRepository.save(orderGroup))
+                .map(orderGroup -> baseRepository.save(orderGroup))
                 .map(orderGroup -> getResponse(orderGroup))
                 .orElseGet(()->Header.ERROR("데이터 없음."));
     }
 
     @Override
     public Header delete(Long id) {
-        Optional<OrderGroup> opt = orderGroupRepository.findById(id);
+        Optional<OrderGroup> opt = baseRepository.findById(id);
         return opt
                 .map(orderGroup->{
-                    orderGroupRepository.delete(orderGroup);
+                    baseRepository.delete(orderGroup);
                     return Header.OK();
                 })
                 .orElseGet(()->Header.ERROR("데이터 없음."));

--- a/src/main/java/com/example/study/service/UserApiLogicService.java
+++ b/src/main/java/com/example/study/service/UserApiLogicService.java
@@ -1,24 +1,18 @@
 package com.example.study.service;
 
-import com.example.study.ifs.CrudInterface;
 import com.example.study.model.entity.User;
 import com.example.study.model.enumClass.ItemStatus;
 import com.example.study.model.enumClass.UserStatus;
 import com.example.study.model.network.Header;
 import com.example.study.model.network.request.UserApiRequest;
 import com.example.study.model.network.response.UserApiResponse;
-import com.example.study.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
-public class UserApiLogicService implements CrudInterface<UserApiRequest, UserApiResponse> {
-
-    @Autowired
-    private UserRepository userRepository;
+public class UserApiLogicService extends BaseService<UserApiRequest, UserApiResponse, User> {
 
     //1. request data 가져오기
     //2. User 생성
@@ -39,7 +33,7 @@ public class UserApiLogicService implements CrudInterface<UserApiRequest, UserAp
                 .email(userApiRequest.getEmail())
                 .registeredAt(LocalDateTime.now())
                 .build();
-        User newUser = userRepository.save(user);
+        User newUser = baseRepository.save(user);
 
         // 3. 생성된 데이터를 기준으로 User API response 만들기
 
@@ -49,7 +43,7 @@ public class UserApiLogicService implements CrudInterface<UserApiRequest, UserAp
     @Override
     public Header<UserApiResponse> read(Long id) {
         // getOne 또는 getById로 데이터를 가져온다.
-        Optional<User> opt= userRepository.findById(id);
+        Optional<User> opt= baseRepository.findById(id);
 
         // 가져온 데이터 user를 이용해 userApiResonse를 리턴해준다.
 
@@ -66,7 +60,7 @@ public class UserApiLogicService implements CrudInterface<UserApiRequest, UserAp
 
         // 2. id를 이용해 user data 찾기
         Long id=body.getId();
-        Optional<User> opt=userRepository.findById(id);
+        Optional<User> opt = baseRepository.findById(id);
 
         return opt.map(user->{
             // 3. Update
@@ -81,7 +75,7 @@ public class UserApiLogicService implements CrudInterface<UserApiRequest, UserAp
                 user.setUnregisteredAt(LocalDateTime.now());     // unregisteredAt 필드 업데이트
             return user;
         })
-                .map(user -> userRepository.save(user))    // update 내역 저장하고, 업데이트된 user 반환
+                .map(user -> baseRepository.save(user))    // update 내역 저장하고, 업데이트된 user 반환
                 .map(user -> getResponse(user))            // 4. 업데이트된 user를 받아 response 생성
                 .orElseGet(()->Header.ERROR("데이터 없음")); // 위의 map 중 하나라도 데이터가 없다면 에러 반환
     }
@@ -89,9 +83,9 @@ public class UserApiLogicService implements CrudInterface<UserApiRequest, UserAp
     @Override
     public Header delete(Long id) {
         // 1. id를 이용해 user 찾기
-        Optional<User> opt = userRepository.findById(id);
+        Optional<User> opt = baseRepository.findById(id);
         return opt.map(user->{
-            userRepository.delete(user);
+            baseRepository.delete(user);
             return Header.OK();
         }).orElseGet(()->Header.ERROR("해당하는 사용자 없음"));
     }


### PR DESCRIPTION
서비스 로직을 추상화하여 관련 클래스들을 수정했다.
 - BaseService라는 추상 클래스를 생성하여 기존 서비스 로직에서 생성하던  repository 변수를 baseRepository라는 하나의 변수로 통일할 수 있다.

 -  BaseService 클래스는 CrudInterface를 구현하며, 제네릭 변수로 Req, Res, 그리고 Entity를 추가로 받는다. 이 Entity는 어떤 엔티티의 repository를 생성할지 정해주는 역할을 하며, protected JpaRepository<Entity, Long> baseRepository; 와 같이 JpaRepository를 생성할 때 사용한다. 이 변수에는 @Autowired(required  = false) 어노테이션을 붙여준다. 또한, Autowired를 사용했으므로 BaseService에는 @Component 어노테이션을 붙여준다.

 -  각 서비스 로직은 BaseService 클래스를 상속받으며, 자기 자신과 연결하는 repository 부분을 baseRepository로 대체할 수 있다.
 
 -  이렇게 하면 CrudController에 baseService 변수를 생성하여 각 컨트롤러에서 서비스 로직과 연결하지 않아도 자동으로 연결되게 할 수 있다. 이렇게 하기위해 CrudController는 Entity 제네릭 변수를 추가로 받으며, 이를 BaseService 클래스에 넘겨서 특정 repository를 생성하도록 할 수 있다. CrudController에는 @Component 어노테이션을, baseService 변수에는@Autowired(required=false) 어노테이션을 붙여준다.